### PR TITLE
Changed WebDataSource and WebResource to ignore Unicode

### DIFF
--- a/Graphics/UI/Gtk/WebKit/WebDataSource.chs
+++ b/Graphics/UI/Gtk/WebKit/WebDataSource.chs
@@ -89,7 +89,7 @@ webDataSourceGetData :: WebDataSourceClass self => self
 webDataSourceGetData ds = do
   gstr <- {#call webkit_web_data_source_get_data #}
                  (toWebDataSource ds)
-  readGString gstr
+  readGStringRaw gstr
 
 -- | Returns the text encoding name as set in the 'WebView', or if not, the text encoding of the response.
 webDataSourceGetEncoding ::

--- a/Graphics/UI/Gtk/WebKit/WebResource.chs
+++ b/Graphics/UI/Gtk/WebKit/WebResource.chs
@@ -80,7 +80,7 @@ webResourceNew resData size uri mimeType encoding frameName =
 -- | Returns the data of the WebResource.
 webResourceGetData :: WebResourceClass self => self -> IO (Maybe String)
 webResourceGetData wr =
-  {#call web_resource_get_data#} (toWebResource wr) >>= readGString
+  {#call web_resource_get_data#} (toWebResource wr) >>= readGStringRaw
 
 -- | Get encoding.
 webResourceGetEncoding :: 


### PR DESCRIPTION
Currently these two classes have their getData methods decode Unicode, undesirable for nontextual resources (and certain textual ones). Using the readGStringRaw function from PR 14 in gtk2hs instead of readGString fixes this.
