### PR TITLE
Build attributes from glib properties whenever possible

### DIFF
--- a/webkit.cabal-renamed
+++ b/webkit.cabal-renamed
@@ -45,7 +45,7 @@ Source-Repository head
 Library
         build-depends:  base >= 4 && < 5,
                         bytestring >= 0.10 && < 0.11,
-                        glib  >= 0.13.0.0 && < 0.14,
+                        glib  >= 0.13.1.0 && < 0.14,
                         pango >= 0.13.0.0 && < 0.14,
                         cairo >= 0.13.0.0 && < 0.14,
                         text  >= 1.0.0.0 && < 1.3,

--- a/webkitgtk3.cabal
+++ b/webkitgtk3.cabal
@@ -45,7 +45,7 @@ Source-Repository head
 Library
         build-depends:  base >= 4 && < 5,
                         bytestring >= 0.10 && < 0.11,
-                        glib  >= 0.13.0.0 && < 0.14,
+                        glib  >= 0.13.1.0 && < 0.14,
                         pango >= 0.13.0.0 && < 0.14,
                         cairo >= 0.13.0.0 && < 0.14,
                         text  >= 1.0.0.0 && < 1.3,


### PR DESCRIPTION
It makes it possible to use `notifyProperty` (from [here][1]).
The code depends on https://github.com/gtk2hs/gtk2hs/pull/94 .

[1]: https://hackage.haskell.org/package/gtk3-0.13.4/docs/Graphics-UI-Gtk-Abstract-Object.html