### PR TITLE
fix double stable pointer free causing segfaults in some situations

### DIFF
--- a/Graphics/UI/Gtk/WebKit/DOM/EventTargetClosures.chs
+++ b/Graphics/UI/Gtk/WebKit/DOM/EventTargetClosures.chs
@@ -54,6 +54,5 @@ foreign import ccall unsafe "g_closure_unref"
 eventListenerRelease :: EventListener -> IO ()
 eventListenerRelease (EventListener gclosurePtr sptr) = do
   g_closure_unref gclosurePtr
-  freeStablePtr sptr
 
 

--- a/Graphics/UI/Gtk/WebKit/DOM/EventTargetClosures.chs
+++ b/Graphics/UI/Gtk/WebKit/DOM/EventTargetClosures.chs
@@ -52,7 +52,5 @@ foreign import ccall unsafe "g_closure_unref"
   g_closure_unref :: Ptr GClosure -> IO ()
 
 eventListenerRelease :: EventListener -> IO ()
-eventListenerRelease (EventListener gclosurePtr sptr) = do
-  g_closure_unref gclosurePtr
-
+eventListenerRelease (EventListener gclosurePtr _) = g_closure_unref gclosurePtr
 


### PR DESCRIPTION
`g_closure_unref` is already freeing the pointer [here](https://github.com/gtk2hs/gtk2hs/blob/dff5deae25a3f2c7d63ae583d1096b626bb6a9d2/glib/System/Glib/hsgclosure.c#L54)

More details here:
https://github.com/ghcjs/ghcjs-dom/issues/37